### PR TITLE
Support side-specific modifier names

### DIFF
--- a/libraries/hotkeys.ah2
+++ b/libraries/hotkeys.ah2
@@ -26,6 +26,14 @@ class HotkeyManager {
     }
 
     static ConvertModifiers(modifiers) {
+        modifiers := StrReplace(modifiers, "LAlt", "<!")
+        modifiers := StrReplace(modifiers, "RAlt", ">!")
+        modifiers := StrReplace(modifiers, "LCtrl", "<^")
+        modifiers := StrReplace(modifiers, "RCtrl", ">^")
+        modifiers := StrReplace(modifiers, "LShift", "<+")
+        modifiers := StrReplace(modifiers, "RShift", ">+")
+        modifiers := StrReplace(modifiers, "LWin", "<#")
+        modifiers := StrReplace(modifiers, "RWin", ">#")
         modifiers := StrReplace(modifiers, "Ctrl", "^")
         modifiers := StrReplace(modifiers, "Alt", "!")
         modifiers := StrReplace(modifiers, "Shift", "+")


### PR DESCRIPTION
## Summary
- handle side-specific modifiers (LAlt, RAlt, etc.) in `ConvertModifiers`
- retain generic modifier replacements

## Testing
- `./virtual-desktop-enhancer.ah2` *(fails: command not found - AutoHotkey not available)*

------
https://chatgpt.com/codex/tasks/task_e_689dc53263d4832d93273cad86bcb590