### PR TITLE
restore default setting

### DIFF
--- a/libraries/hotkeys.ah2
+++ b/libraries/hotkeys.ah2
@@ -39,6 +39,7 @@ class HotkeyManager {
         modifiers := StrReplace(modifiers, "Shift", "+")
         modifiers := StrReplace(modifiers, "Win", "#")
         modifiers := StrReplace(modifiers, ",", "")
+        modifiers := StrReplace(modifiers, " ", "")
         return modifiers
     }
 

--- a/settings.ini
+++ b/settings.ini
@@ -15,9 +15,9 @@ BackgroundColor=0x1F1F1F
 
 [KeyboardShortcuts]
 ; Modifier keys for desktop switching actions
-SwitchDesktop=Win
-MoveWindowToDesktop=Win,Ctrl
-MoveWindowAndSwitchToDesktop=
+SwitchDesktop=Win, Ctrl
+MoveWindowToDesktop=
+MoveWindowAndSwitchToDesktop=Win, Ctrl, Shift
 
 ; Identifier keys for desktop switching
 PreviousDesktop=Left
@@ -34,22 +34,22 @@ Desktop9=9
 Desktop10=0
 
 ; Alternative identifier keys
-DesktopAlt1=F1
-DesktopAlt2=F2
-DesktopAlt3=F3
-DesktopAlt4=F4
-DesktopAlt5=F5
-DesktopAlt6=F6
-DesktopAlt7=F7
-DesktopAlt8=F8
-DesktopAlt9=F9
-DesktopAlt10=F10
+DesktopAlt1=Numpad1
+DesktopAlt2=Numpad2
+DesktopAlt3=Numpad3
+DesktopAlt4=Numpad4
+DesktopAlt5=Numpad5
+DesktopAlt6=Numpad6
+DesktopAlt7=Numpad7
+DesktopAlt8=Numpad8
+DesktopAlt9=Numpad9
+DesktopAlt10=Numpad0
 
 ; Other shortcuts
-OpenDesktopManager=Ctrl,Win,D
-TogglePinWindow=Ctrl,Win,P
-TogglePinApp=Ctrl,Shift,Win,P
-PinWindow=Ctrl,Win,Shift,P
-UnPinWindow=Ctrl,Win,Alt,P
-PinApp=Ctrl,Win,Shift,A
-UnPinApp=Ctrl,Win,Alt,A 
+OpenDesktopManager=LAlt, SC029
+TogglePinWindow=Win, Ctrl, Shift, Q
+TogglePinApp=Win, Ctrl, Shift, A
+PinWindow=
+UnPinWindow=
+PinApp=
+UnPinApp=

--- a/settings.ini
+++ b/settings.ini
@@ -46,7 +46,7 @@ DesktopAlt9=Numpad9
 DesktopAlt10=Numpad0
 
 ; Other shortcuts
-OpenDesktopManager=LAlt, SC029
+OpenDesktopManager=LAlt, ~
 TogglePinWindow=Win, Ctrl, Shift, Q
 TogglePinApp=Win, Ctrl, Shift, A
 PinWindow=


### PR DESCRIPTION
This PR updates the settings.ini to restore the default keybindings for desktop switching.

The previous configuration was not intentional — I had accidentally published the settings I was personally using at the time of the initial release. It wasn't meant to override the Windows default shortcuts.

To avoid confusion, I'm reverting the keybindings to match the standard Windows behavior.

I used the keybindings from win-10-virtual-desktop-enhancer as a reference, so I believe this should be correct — but if you notice any differences from the actual Windows defaults, please let me know!